### PR TITLE
fix circular imports and a latent name-shadowing bug

### DIFF
--- a/fovi/arch/architectures.py
+++ b/fovi/arch/architectures.py
@@ -11,8 +11,7 @@ from .knnvit import KNNViT
 from .vit import VisionTransformer
 from .dinov3 import build_fovi_dinov3
 from .mlp import get_mlp
-from . import resnet
-from ..sensing.retina import get_min_cmf_a
+from .resnet import resnet_ssl as _resnet_ssl
 from ..utils import HiddenPrints, add_to_all
 
 __all__ = []
@@ -158,7 +157,7 @@ def resnet(cfg, layers, device='cuda'):
     assert cfg.model.arch_flag == None or not len(cfg.model.arch_flag), 'variable architecture flag not implemented for resnet'
 
     polar='polar' in cfg.saccades.mode and 'comp' not in cfg.saccades.mode
-    network = resnet.resnet_ssl(layers=layers, mlp_kwargs=mlp_kwargs, polar=polar,
+    network = _resnet_ssl(layers=layers, mlp_kwargs=mlp_kwargs, polar=polar,
                                             out_map_size=cfg.model.final_grid_size,
                                             **backbone_kwargs,
                                             )
@@ -461,6 +460,7 @@ def rescale_fov(cfg):
         assert crop_area_range[0] == crop_area_range[1], 'only allow single sized training crops when rescaling FOV (either with rescale_fov or with auto cmf_a)'
         crop_size = np.sqrt(crop_area_range[0])*cfg.saccades.fixation_size
         if cmf_a == -1 or cmf_a == 'auto':
+            from ..sensing.retina import get_min_cmf_a
             cmf_a = get_min_cmf_a(crop_size, cfg.saccades.resize_size, cfg.saccades.fixation_size, fov=fov, style=cfg.saccades.mode)
         # auto FOV assumes the field-of-view is adjusted based on the crop size. this should always be the case, but for backwards compatibility it is not.
         fov = fov*(crop_size/cfg.saccades.fixation_size)

--- a/fovi/utils/fastaugs/__init__.py
+++ b/fovi/utils/fastaugs/__init__.py
@@ -5,9 +5,9 @@ This module contains fast image augmentation operations optimized for
 foveated vision processing.
 """
 
-from .transforms import *
 from .functional import *
 from .functional_tensor import *
+from .transforms import *
 try:
     from .loader import *
 except:

--- a/fovi/utils/fastaugs/transforms.py
+++ b/fovi/utils/fastaugs/transforms.py
@@ -3,8 +3,9 @@ import torch
 import numbers
 from torch.nn.modules.utils import _pair
 
-from . import functional as F
-from . import functional_tensor as FT
+import importlib as _importlib
+F = _importlib.import_module('.functional', __package__)
+FT = _importlib.import_module('.functional_tensor', __package__)
 
 __all__ = [
             # utility transforms

--- a/fovi/utils/flops.py
+++ b/fovi/utils/flops.py
@@ -10,7 +10,6 @@ import torch
 from contextlib import nullcontext
 from statistics import mean, median
 
-from .. import get_trainer_from_base_fn
 from . import add_to_all
 
 __all__ = []
@@ -449,6 +448,7 @@ def get_flops_df(runs_df, include_keys, compute_latency=False, compute_memory=Fa
     for key in include_keys:
         short_key = key.split('.')[-1]
         flops_df[short_key] = []
+    from .. import get_trainer_from_base_fn
     for ii, row in runs_df.iterrows():
         base_fn = row['logging.base_fn']
         trainer = get_trainer_from_base_fn(base_fn, quiet=quiet, load=True, **kwargs)


### PR DESCRIPTION
- arch/architectures.py: replace `from . import resnet` with direct submodule import, breaking the fovi.arch <-> fovi.arch.architectures cycle. Also fixes a bug where the local `resnet()` function shadowed the imported module, making `resnet.resnet_ssl()` unreachable.
- arch/architectures.py: move `from ..sensing.retina import get_min_cmf_a` into rescale_fov() as a lazy import, breaking the retina -> samplers -> arch/__init__ -> architectures -> retina cycle.
- utils/fastaugs/transforms.py: use importlib.import_module for sibling module imports, breaking the fastaugs <-> transforms cycle.
- utils/fastaugs/__init__.py: reorder imports so functional modules load before transforms.
- utils/flops.py: move top-level-package import into the function that uses it, eliminating a reverse dependency from utils to fovi.