### PR TITLE
build: switch to hatchling to fix editable install namespace shadowing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["setuptools>=64", "wheel"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling", "hatch-requirements-txt"]
+build-backend = "hatchling.build"
 
 [project]
 name = "fovi"
@@ -9,9 +9,8 @@ description = "A foveated interface for deep vision models"
 requires-python = ">=3.9"
 dynamic = ["dependencies"]
 
-[tool.setuptools.dynamic]
-dependencies = {file = ["fovi/requirements.txt"]}
+[tool.hatch.metadata.hooks.requirements_txt]
+files = ["fovi/requirements.txt"]
 
-[tool.setuptools.packages.find]
-where = ["."]
-include = ["fovi*"] 
+[tool.hatch.build.targets.wheel]
+packages = ["fovi"]


### PR DESCRIPTION
setuptools editable installs add the repo root to sys.path, causing the outer fovi/ directory to shadow the inner fovi/fovi/ package under some circumstances (unclear what these circumstances are, since this appeared recently with no changes to the pyproject.toml install) 

hatchling's editable install uses a proper import hook that resolves correctly.